### PR TITLE
Create transcriptome_properties.py

### DIFF
--- a/transcriptome_properties.py
+++ b/transcriptome_properties.py
@@ -325,7 +325,7 @@ def process_line(line):
         len_outfile.write("%s,%d\n" % (transcriptID, seqlen))
 
     if (args.exonct):
-        exonct_outfile.write("%s,%s\n" % (transcriptID, txid_to_exonct[transcriptID]))
+        exonct_outfile.write("%s,%s\n" % (transcriptID, txid_to_exonct[transcriptID.split("::")[0]]))
         
     if (args.cap_structure): 
         # calculate the deltaG of the 50nt after the 5' end here, or if the 5' UTR is less than 50nt just calculate the deltaG of the whole thing.


### PR DESCRIPTION
Dear Dr. Floor,
thanks for your fantastic program for calculating transcriptome properties. 
Due to exonct have "0" in output file. I found this problem is txid_to_exonct indexing error. The transcriptID should be without "::".
Baoqiang Chen: cbq19@mails.tsinghua.edu.cn